### PR TITLE
Follow the upstream fixs

### DIFF
--- a/local.js
+++ b/local.js
@@ -186,7 +186,7 @@
           buf = new Buffer(10);
           buf.write("\u0005\u0000\u0000\u0001", 0, 4, "binary");
           buf.write("\u0000\u0000\u0000\u0000", 4, 4, "binary");
-          buf.writeInt16BE(remotePort, 8);
+          buf.writeUInt16BE(remotePort, 8);
           connection.write(buf);
           if (HTTPPROXY) {
             endpoint = aServer;

--- a/src/local.coffee
+++ b/src/local.coffee
@@ -137,7 +137,7 @@ server = net.createServer (connection) ->
         buf = new Buffer(10)
         buf.write "\u0005\u0000\u0000\u0001", 0, 4, "binary"
         buf.write "\u0000\u0000\u0000\u0000", 4, 4, "binary"
-        buf.writeInt16BE remotePort, 8
+        buf.writeUInt16BE remotePort, 8
         connection.write buf
         # connect to remote server
         # ws = new WebSocket aServer, protocol: "binary"


### PR DESCRIPTION
```c
TypeError: "value" argument is out of bounds
    at checkInt (buffer.js:1185:11)
    at Buffer.writeInt16BE (buffer.js:1364:5)
    at Socket.<anonymous> (/root/local.js:189:15)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
    at TCP.onread (net.js:594:20)
```
https://github.com/mrluanma/shadowsocks-heroku/pull/40